### PR TITLE
Fixed commons-compress version to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <version.dep.aspectjrt>1.8.5</version.dep.aspectjrt>
     <version.dep.commons-codec>1.6</version.dep.commons-codec>
     <version.dep.commons-collections>3.2.1</version.dep.commons-collections>
-    <verison.dep.commons-compress>1.7-SNAPSHOT</verison.dep.commons-compress>
+    <verison.dep.commons-compress>1.7</verison.dep.commons-compress>
     <version.dep.commons-io>1.4</version.dep.commons-io>
     <version.dep.commons-jxpath>1.3</version.dep.commons-jxpath>
     <version.dep.commons-lang>2.5</version.dep.commons-lang>


### PR DESCRIPTION
The SNAPSHOT version is not available for general public, plus the 1.7 release already exists.
