### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- Dependencies -->
     <version.dep.aspectjrt>1.8.5</version.dep.aspectjrt>
     <version.dep.commons-codec>1.6</version.dep.commons-codec>
-    <version.dep.commons-collections>3.2.1</version.dep.commons-collections>
+    <version.dep.commons-collections>3.2.2</version.dep.commons-collections>
     <version.dep.commons-compress>1.7</version.dep.commons-compress>
     <version.dep.commons-io>1.4</version.dep.commons-io>
     <version.dep.commons-jxpath>1.3</version.dep.commons-jxpath>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
